### PR TITLE
WIP: Re-design watch API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ use crate::rpc::maintenance::{
     AlarmAction, AlarmOptions, AlarmResponse, AlarmType, DefragmentResponse, HashKvResponse,
     HashResponse, MaintenanceClient, MoveLeaderResponse, SnapshotStreaming, StatusResponse,
 };
-use crate::rpc::watch::{WatchClient, WatchOptions, WatchStream, Watcher};
+use crate::rpc::watch::{WatchClient, WatchOptions, WatchStream};
 #[cfg(feature = "tls-openssl")]
 use crate::OpenSslResult;
 #[cfg(feature = "tls")]
@@ -449,7 +449,7 @@ impl Client {
         &mut self,
         key: impl Into<Vec<u8>>,
         options: Option<WatchOptions>,
-    ) -> Result<(Watcher, WatchStream)> {
+    ) -> Result<WatchStream> {
         self.watch.watch(key, options).await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,7 +41,6 @@ use crate::rpc::watch::{WatchClient, WatchOptions, WatchStream, Watcher};
 use crate::OpenSslResult;
 #[cfg(feature = "tls")]
 use crate::TlsOptions;
-use crate::WatchResponse;
 use http::uri::Uri;
 use http::HeaderValue;
 
@@ -450,7 +449,7 @@ impl Client {
         &mut self,
         key: impl Into<Vec<u8>>,
         options: Option<WatchOptions>,
-    ) -> Result<(WatchResponse, Watcher, WatchStream)> {
+    ) -> Result<(Watcher, WatchStream)> {
         self.watch.watch(key, options).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,6 @@ pub use crate::rpc::maintenance::{
 };
 pub use crate::rpc::watch::{
     Event, EventType, WatchClient, WatchFilterType, WatchOptions, WatchResponse, WatchStream,
-    Watcher,
 };
 pub use crate::rpc::{KeyValue, ResponseHeader};
 

--- a/src/rpc/watch.rs
+++ b/src/rpc/watch.rs
@@ -49,27 +49,24 @@ impl WatchClient {
 
     /// Watches for events happening or that have happened. Both input and output
     /// are streams; the input stream is for creating and canceling watchers and the output
-    /// stream sends events. One watch RPC can watch on multiple key ranges, streaming events
-    /// for several watches at once. The entire event history can be watched starting from the
+    /// stream receives resposnes and events.
+    ///
+    /// One watch stream can watch on multiple key ranges, streaming events for several watches
+    /// are grouped by watch ID. The entire event history can be watched starting from the
     /// last compaction revision.
     pub async fn watch(
         &mut self,
         key: impl Into<Vec<u8>>,
         options: Option<WatchOptions>,
-    ) -> Result<(Watcher, WatchStream)> {
+    ) -> Result<WatchStream> {
         let (request_sender, request_receiver) = channel::<WatchRequest>(100);
-        let request_stream = ReceiverStream::new(request_receiver);
-
         request_sender
             .send(options.unwrap_or_default().with_key(key).into())
             .await
             .map_err(|e| Error::WatchError(e.to_string()))?;
-
+        let request_stream = ReceiverStream::new(request_receiver);
         let response_stream = self.inner.watch(request_stream).await?.into_inner();
-        Ok((
-            Watcher::new(request_sender),
-            WatchStream::new(response_stream),
-        ))
+        Ok(WatchStream::new(request_sender, response_stream))
     }
 }
 
@@ -346,15 +343,22 @@ impl Event {
 /// The watching handle.
 #[cfg_attr(feature = "pub-response-field", visible::StructFields(pub))]
 #[derive(Debug)]
-pub struct Watcher {
-    sender: Sender<WatchRequest>,
+pub struct WatchStream {
+    request_stream: Sender<WatchRequest>,
+    response_stream: Streaming<PbWatchResponse>,
 }
 
-impl Watcher {
-    /// Creates a new `Watcher`.
+impl WatchStream {
+    /// Creates a new `WatchStream`.
     #[inline]
-    const fn new(sender: Sender<WatchRequest>) -> Self {
-        Self { sender }
+    const fn new(
+        request_stream: Sender<WatchRequest>,
+        response_stream: Streaming<PbWatchResponse>,
+    ) -> Self {
+        Self {
+            request_stream,
+            response_stream,
+        }
     }
 
     /// Watches for events happening or that have happened.
@@ -364,7 +368,7 @@ impl Watcher {
         key: impl Into<Vec<u8>>,
         options: Option<WatchOptions>,
     ) -> Result<()> {
-        self.sender
+        self.request_stream
             .send(options.unwrap_or_default().with_key(key).into())
             .await
             .map_err(|e| Error::WatchError(e.to_string()))
@@ -374,7 +378,7 @@ impl Watcher {
     #[inline]
     pub async fn cancel(&mut self, watch_id: i64) -> Result<()> {
         let req = WatchCancelRequest { watch_id };
-        self.sender
+        self.request_stream
             .send(req.into())
             .await
             .map_err(|e| Error::WatchError(e.to_string()))
@@ -385,34 +389,24 @@ impl Watcher {
     #[inline]
     pub async fn request_progress(&mut self) -> Result<()> {
         let req = WatchProgressRequest {};
-        self.sender
+        self.request_stream
             .send(req.into())
             .await
             .map_err(|e| Error::WatchError(e.to_string()))
     }
-}
 
-/// The watch response stream.
-#[cfg_attr(feature = "pub-response-field", visible::StructFields(pub))]
-#[derive(Debug)]
-pub struct WatchStream {
-    stream: Streaming<PbWatchResponse>,
-}
-
-impl WatchStream {
-    /// Creates a new `WatchStream`.
-    #[inline]
-    const fn new(stream: Streaming<PbWatchResponse>) -> Self {
-        Self { stream }
-    }
-
-    /// Fetch the next message from this stream.
+    /// Receive WatchResponse from this watch stream.
     #[inline]
     pub async fn message(&mut self) -> Result<Option<WatchResponse>> {
-        match self.stream.message().await? {
+        match self.response_stream.message().await? {
             Some(resp) => Ok(Some(WatchResponse::new(resp))),
             None => Ok(None),
         }
+    }
+
+    /// Splits the watch stream into a sender and a receiver.
+    pub fn split(self) -> (Sender<WatchRequest>, Streaming<PbWatchResponse>) {
+        (self.request_stream, self.response_stream)
     }
 }
 
@@ -421,7 +415,7 @@ impl Stream for WatchStream {
 
     #[inline]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().stream)
+        Pin::new(&mut self.get_mut().response_stream)
             .poll_next(cx)
             .map(|t| match t {
                 Some(Ok(resp)) => Some(Ok(WatchResponse::new(resp))),

--- a/src/rpc/watch.rs
+++ b/src/rpc/watch.rs
@@ -56,7 +56,7 @@ impl WatchClient {
         &mut self,
         key: impl Into<Vec<u8>>,
         options: Option<WatchOptions>,
-    ) -> Result<(WatchResponse, Watcher, WatchStream)> {
+    ) -> Result<(Watcher, WatchStream)> {
         let (request_sender, request_receiver) = channel::<WatchRequest>(100);
         let request_stream = ReceiverStream::new(request_receiver);
 
@@ -66,27 +66,10 @@ impl WatchClient {
             .map_err(|e| Error::WatchError(e.to_string()))?;
 
         let response_stream = self.inner.watch(request_stream).await?.into_inner();
-        let mut watch_stream = WatchStream::new(response_stream);
-
-        match watch_stream.message().await? {
-            Some(resp) => {
-                match (resp.created(), resp.canceled()) {
-                    // this is a create watch success response
-                    (true, false) => Ok((resp, Watcher::new(request_sender), watch_stream)),
-                    // this is a create watch failed response
-                    (true, true) => Err(Error::WatchError(resp.cancel_reason().into())),
-                    // this is a cancel watch response, unexpected when we first create a watch
-                    (false, true) => {
-                        Err(Error::WatchError("unexpected watch cancel response".into()))
-                    }
-                    // this is an event response
-                    (false, false) => {
-                        Err(Error::WatchError("unexpected watch event response".into()))
-                    }
-                }
-            }
-            None => Err(Error::WatchError("failed to create watch".into())),
-        }
+        Ok((
+            Watcher::new(request_sender),
+            WatchStream::new(response_stream),
+        ))
     }
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -246,7 +246,16 @@ async fn test_txn() -> Result<()> {
 async fn test_watch() -> Result<()> {
     let mut client = get_client().await?;
 
-    let (first_response, mut watcher, mut stream) = client.watch("watch01", None).await?;
+    let (mut watcher, mut stream) = client.watch("watch01", None).await?;
+    let first_response = stream
+        .message()
+        .await?
+        .ok_or(etcd_client::Error::WatchError(
+            "No initial watch response".into(),
+        ))?;
+
+    assert!(first_response.created());
+    assert!(!first_response.canceled());
     let watch_id = first_response.watch_id();
 
     client.put("watch01", "01", None).await?;


### PR DESCRIPTION
Based on https://github.com/etcdv3/etcd-client/pull/104

The `WatchClient` is not a high level watcher, it is just a watch API stub. So it should be only responsible for sending requests and receiving responses. Let the high level watcher decide what to do if received an unexpected response.

```diff
- WatchClient::watch(key: impl Into<Vec<u8>>, options: Option<WatchOptions>) -> Result<(WatchResponse, Watcher, WatchStream)>
+ WatchClient::watch(key: impl Into<Vec<u8>>, options: Option<WatchOptions>) -> Result<WatchStream>
```

The new `WatchStream` is different from the old version. It represents underlying bidirectional watch stream (HTTP2 stream). So it can be used to send requests and receive responses and events.

It's the user's responsibility to check the received response is a response or an event, if it is created successfully or not, or if it is a cancel response.